### PR TITLE
Update demo pipeline to rename content files with current year

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -38,6 +38,15 @@ jobs:
           
       - name: Rename content-demo folder to content and wrangler-demo.toml to wrangler.toml
         run: |
+          # Rename all files in src/content-demo to have the current year in their filenames
+          CURRENT_YEAR=$(date +%Y)
+          for file in src/content-demo/*.md; do
+            filename=$(basename "$file")
+            # Assumes filename starts with a 4-digit year (e.g., 2025-01-01.md)
+            new_filename="${CURRENT_YEAR}${filename:4}"
+            mv "$file" "src/content-demo/$new_filename"
+          done
+
           rm -rf ./src/content
           mv ./src/content-demo ./src/content
           rm ./wrangler.toml


### PR DESCRIPTION
Updated the `demo.yml` workflow to include a bash step that renames all Markdown files in `src/content-demo` to reflect the current year. The renaming happens before the files are moved to `src/content`, ensuring the demo deployment uses the most up-to-date year in its filenames. Tested locally by simulating the renaming logic and verifying that the Astro build processes the renamed files correctly.

---
*PR created automatically by Jules for task [15050034989071163869](https://jules.google.com/task/15050034989071163869) started by @tylermercer*